### PR TITLE
Fix Branch Routing, update user-settings

### DIFF
--- a/api/src/database/entity/UserSettings.ts
+++ b/api/src/database/entity/UserSettings.ts
@@ -13,14 +13,14 @@ export class UserSettings implements IUserSettings {
   lastName: string;
 
   @Column()
-  profileLink: string;
+  profileImageUrl: string;
 
   static Default(userId = ''): UserSettings {
     return {
       id: userId,
       firstName: '',
       lastName: '',
-      profileLink: '',
+      profileImageUrl: '',
     } satisfies UserSettings;
   }
 }

--- a/api/src/database/entity/UserSettings.ts
+++ b/api/src/database/entity/UserSettings.ts
@@ -1,9 +1,9 @@
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 import type { IUserSettings } from '@db/models/UserSettings.d';
+import { Column, Entity, PrimaryColumn } from 'typeorm';
 
 @Entity('UserSettings')
 export class UserSettings implements IUserSettings {
-  @PrimaryGeneratedColumn('uuid')
+  @PrimaryColumn({ type: 'nvarchar', length: 1024 })
   id: string;
 
   @Column()

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -18,6 +18,14 @@
   "trailingSlash": "auto",
   "routes": [
     {
+      "route": "/office*",
+      "allowedRoles": ["authenticated"]
+    },
+    {
+      "route": "/sitting-room*",
+      "allowedRoles": ["authenticated"]
+    },
+    {
       "route": "/foyer*",
       "allowedRoles": ["anonymous"]
     },
@@ -28,10 +36,6 @@
     {
       "route": "/logout",
       "rewrite": "/.auth/logout"
-    },
-    {
-      "route": "/*",
-      "allowedRoles": ["authenticated"]
     }
   ],
   "responseOverrides": {

--- a/swa-db-connections/models/UserSettings.d.ts
+++ b/swa-db-connections/models/UserSettings.d.ts
@@ -9,5 +9,5 @@ export interface IUserSettings {
   /** An optional value indicating the user's preferred last name. */
   lastName: string;
   /** An optional value indicating the user's preferred profile image. TODO: remove */
-  profileLink: string;
+  profileImageUrl: string;
 }

--- a/ui/src/components/pages/ProfilePage.vue
+++ b/ui/src/components/pages/ProfilePage.vue
@@ -17,28 +17,22 @@ import { useNativeAuth } from '@/auth/useNativeAuth';
 const nativeAuth = useNativeAuth();
 const { curUser } = storeToRefs(nativeAuth);
 
-const items = computed<EnumObject[]>(() => {
-  if (!curUser.value?.clientPrincipal?.claims?.length) {
-    return [];
-  }
-
-  return [
-    {
-      label: 'Username',
-      value: curUser.value.clientPrincipal.userDetails ?? 'Unknown',
-    },
-    {
-      label: 'Provider',
-      value: JSON.stringify(curUser.value.clientPrincipal.identityProvider ?? []),
-    },
-    {
-      label: 'Claims',
-      value: JSON.stringify(curUser.value.clientPrincipal.claims ?? []),
-    },
-    {
-      label: 'Roles',
-      value: JSON.stringify(curUser.value.clientPrincipal.userRoles ?? []),
-    },
-  ];
-});
+const items = computed<EnumObject[]>(() => [
+  {
+    label: 'Username',
+    value: curUser.value?.clientPrincipal.userDetails ?? 'Unknown',
+  },
+  {
+    label: 'Provider',
+    value: JSON.stringify(curUser.value?.clientPrincipal.identityProvider ?? []),
+  },
+  {
+    label: 'Claims',
+    value: JSON.stringify(curUser.value?.clientPrincipal.claims ?? []),
+  },
+  {
+    label: 'Roles',
+    value: JSON.stringify(curUser.value?.clientPrincipal.userRoles ?? []),
+  },
+]);
 </script>

--- a/ui/src/components/pages/UserSettings.vue
+++ b/ui/src/components/pages/UserSettings.vue
@@ -59,7 +59,7 @@ const fieldConfigs: ModelFieldConfig<UserSettings>[] = [
     placeholder: 'Smith',
   },
   {
-    key: 'profileLink',
+    key: 'profileImageUrl',
     disabled: true,
     label: 'Profile Link',
   },

--- a/ui/src/layouts/SimpleDark.vue
+++ b/ui/src/layouts/SimpleDark.vue
@@ -152,12 +152,12 @@
               >
                 <!-- Possible profile image -->
                 <div
-                  v-if="myUserSettings?.profileLink"
+                  v-if="myUserSettings?.profileImageUrl"
                   class="flex-shrink-0"
                 >
                   <img
                     class="h-10 w-10 rounded-full"
-                    :src="myUserSettings.profileLink"
+                    :src="myUserSettings.profileImageUrl"
                     alt=""
                   />
                 </div>

--- a/ui/src/repos/user-settings/UserSettings.d.ts
+++ b/ui/src/repos/user-settings/UserSettings.d.ts
@@ -9,5 +9,5 @@ export interface UserSettings {
   /** An optional value indicating the user's preferred last name. */
   lastName: string;
   /** An optional value indicating the user's preferred profile image. TODO: remove */
-  profileLink: string;
+  profileImageUrl: string;
 }

--- a/ui/src/repos/user-settings/index.ts
+++ b/ui/src/repos/user-settings/index.ts
@@ -4,7 +4,7 @@ export const getDefaultUserSettings = (userId: string): UserSettings => ({
   id: userId,
   firstName: '',
   lastName: '',
-  profileLink: '',
+  profileImageUrl: '',
 });
 
 export * from './UserSettings.d';


### PR DESCRIPTION
# Checks
![Azure Static Web Apps CI/CD](https://github.com/bparker-github/noodles-house/actions/workflows/azure-static-web-apps-thankful-pebble-0fd322f0f.yml)

# Changes
- User Settings allows non-guid ids now
  - The native apple identifier is not a guid, we can just restrict it to a thousand character string
- Simplify Profile dump page for empty claims.
- Remove "whole app" authentication guard in favor of guarding the three main rooms thusfar.
