### PR TITLE
Storage Timeout and UserSettings cleanup

### DIFF
--- a/api/src/database/entity/TodoTask.ts
+++ b/api/src/database/entity/TodoTask.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
-import type { TaskType, TodoTask } from '@db/models/TodoTask.d';
+import { TaskState, type TaskType, type TodoTask } from '@db/models/TodoTask.d';
 
 @Entity('TodoTask')
 export class TodoTaskModel extends BaseEntity implements TodoTask {
@@ -15,6 +15,8 @@ export class TodoTaskModel extends BaseEntity implements TodoTask {
   subTitle: string;
   @Column('nvarchar', { nullable: true })
   description: string;
+  @Column('nvarchar', { length: 255, nullable: false, default: TaskState.REPORTED })
+  state: TaskState;
 
   /** Audit details */
   @Column('varchar', { length: 63, nullable: false })

--- a/swa-db-connections/models/TodoTask.d.ts
+++ b/swa-db-connections/models/TodoTask.d.ts
@@ -9,12 +9,25 @@ export interface TodoTask {
   description?: string;
   /** The type of task this represents. */
   type: TaskType;
+  /** The current state of this task. */
+  state: TaskState;
 
   /** Audit details */
   createdBy: string;
   createdAt: Date;
   updatedBy?: string;
   updatedAt?: Date;
+}
+
+export const enum TaskState {
+  REPORTED = 'Reported',
+  PONDERING = 'Pondering',
+  IN_PROGRESS = 'In Progress',
+  NOT_POSSIBLE = 'Not Possible',
+  NOT_DOING = 'Not Doing',
+  NOT_DOING_NOW = 'Not Doing Now',
+  COMPLETED = 'Completed',
+  HELD_UP = 'Held Up',
 }
 
 export const enum TaskType {

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -11,11 +11,13 @@ import { onMounted, ref } from 'vue';
 import { useRouter } from 'vue-router';
 import PageSpinner from './components/spinners/PageSpinner.vue';
 import { useNativeAuth } from './auth/useNativeAuth';
+import { userSettingsRepository } from './repos/user-settings';
 
 const loading = ref(true);
 
 const router = useRouter();
 const nativeAuth = useNativeAuth();
+const userSettings = userSettingsRepository();
 
 onMounted(async () => {
   await Promise.all([
@@ -24,6 +26,9 @@ onMounted(async () => {
     // Ensure the router has loaded before continuing.
     router.isReady(),
   ]);
+
+  // Begin, but don't await fetching UserSettings
+  userSettings.getUserSettings();
 
   // Complete loading.
   loading.value = false;

--- a/ui/src/auth/useNativeAuth.ts
+++ b/ui/src/auth/useNativeAuth.ts
@@ -1,12 +1,11 @@
-import { useFetch, useSessionStorage } from '@vueuse/core';
+import { useTimedStorage } from '@/lib/useTimedStorage';
+import { useFetch } from '@vueuse/core';
 import { defineStore } from 'pinia';
 import { computed } from 'vue';
 import type { NativeUser } from './NativeUser';
 
 export const useNativeAuth = defineStore('native-swa-auth', () => {
-  const curUser = useSessionStorage<NativeUser | null>('[nh]auth-me', null, {
-    serializer: { read: JSON.parse, write: JSON.stringify },
-  });
+  const curUser = useTimedStorage<NativeUser>({ keyName: 'auth-me' });
 
   const nativeAuthFetch = useFetch('/.auth/me', {
     immediate: false,
@@ -19,7 +18,7 @@ export const useNativeAuth = defineStore('native-swa-auth', () => {
   const fetchError = computed(() => nativeAuthFetch.error.value);
 
   const isAuthenticated = computed(() => !!curUser.value?.clientPrincipal);
-  const userId = computed(() => curUser.value?.clientPrincipal.userId);
+  const userId = computed(() => curUser.value?.clientPrincipal?.userId);
 
   async function doFetch(force = false): Promise<void> {
     // Return the promise that's awaiting this fetch.

--- a/ui/src/components/pages/UserSettings.vue
+++ b/ui/src/components/pages/UserSettings.vue
@@ -64,7 +64,7 @@ const fieldConfigs: ModelFieldConfig<IUserSettings>[] = [
 
 // Functions
 async function getUserSettings(): Promise<void> {
-  const foundSettings = await userSettingsRepo.getUserSettings();
+  const foundSettings = await userSettingsRepo.getUserSettings(true);
 
   myUserSettings.value = foundSettings ?? getDefaultUserSettings(userId.value ?? '');
 }

--- a/ui/src/components/pages/auth/LogoutPage.vue
+++ b/ui/src/components/pages/auth/LogoutPage.vue
@@ -5,12 +5,16 @@
 <script setup lang="ts">
 import { useNativeAuth } from '@/auth/useNativeAuth';
 import PageSpinner from '@/components/spinners/PageSpinner.vue';
+import { userSettingsRepository } from '@/repos/user-settings';
 import { onBeforeMount } from 'vue';
 
 const authStore = useNativeAuth();
+const userSettings = userSettingsRepository();
 
 onBeforeMount(() => {
   authStore.clearAuthCache();
+  userSettings.clearSettingsCache();
+
   window.location.pathname = '/logout';
 });
 </script>

--- a/ui/src/components/tasks/TaskCreateCard.vue
+++ b/ui/src/components/tasks/TaskCreateCard.vue
@@ -59,7 +59,7 @@
 import NoofSelect from '@/Noof/inputs/NoofSelect.vue';
 import { useNativeAuth } from '@/auth/useNativeAuth';
 import { EnumObject } from '@/lib';
-import { TaskType, type TodoTask } from '@db/models/TodoTask.d';
+import { TaskState, TaskType, type TodoTask } from '@db/models/TodoTask.d';
 import { storeToRefs } from 'pinia';
 import { computed, ref } from 'vue';
 import NoofInput from '../../Noof/inputs/NoofInput.vue';
@@ -77,6 +77,7 @@ const taskModel = ref<TodoTask>({
   id: '',
   title: '',
   type: TaskType.UNSPECIFIED,
+  state: TaskState.REPORTED,
   description: '',
   subTitle: '',
 });
@@ -109,6 +110,7 @@ async function onSubmit() {
     title: createTaskTitle.value,
     description: createTaskDescription.value,
     type: TaskType.UNSPECIFIED,
+    state: TaskState.REPORTED,
     createdAt: new Date(),
     createdBy: userId.value ?? 'Unknown user',
     id: '',

--- a/ui/src/components/tasks/TasksNavigation.vue
+++ b/ui/src/components/tasks/TasksNavigation.vue
@@ -52,9 +52,7 @@ import { useTaskStore } from '@/stores/tasksStore';
 import { DocumentPlusIcon, ListBulletIcon } from '@heroicons/vue/24/outline';
 import { storeToRefs } from 'pinia';
 import type { FunctionalComponent } from 'vue';
-import { onBeforeMount } from 'vue';
-import { onMounted } from 'vue';
-import { computed } from 'vue';
+import { computed, onBeforeMount } from 'vue';
 import { type RouteLocationRaw } from 'vue-router';
 
 interface TaskNavItem {

--- a/ui/src/components/tasks/TasksNavigation.vue
+++ b/ui/src/components/tasks/TasksNavigation.vue
@@ -52,6 +52,8 @@ import { useTaskStore } from '@/stores/tasksStore';
 import { DocumentPlusIcon, ListBulletIcon } from '@heroicons/vue/24/outline';
 import { storeToRefs } from 'pinia';
 import type { FunctionalComponent } from 'vue';
+import { onBeforeMount } from 'vue';
+import { onMounted } from 'vue';
 import { computed } from 'vue';
 import { type RouteLocationRaw } from 'vue-router';
 
@@ -78,4 +80,9 @@ const navigation = computed<TaskNavItem[]>(() => [
     badge: `${knownTasks.value?.length}` ?? undefined,
   },
 ]);
+
+// Begin but don't await the TaskList call before mount.
+onBeforeMount(() => {
+  taskStore.getAllTasks();
+});
 </script>

--- a/ui/src/lib/useTimedStorage.ts
+++ b/ui/src/lib/useTimedStorage.ts
@@ -20,13 +20,31 @@ interface TimedStorageVal<T> {
   value: T;
 }
 
-export function useTimedStorage<T>({
-  keyName,
-  initialValue = null,
-  liveTime = 5 * 60 * 1000,
-  storage = sessionStorage,
-  storageOptions = {},
-}: UseTimedStorageOptions<T>): WritableComputedRef<T | null> {
+export function useTimedStorage<T>(keyName: string): WritableComputedRef<T | null>;
+export function useTimedStorage<T>(
+  options: UseTimedStorageOptions<T>
+): WritableComputedRef<T | null>;
+export function useTimedStorage<T>(
+  arg1: string | UseTimedStorageOptions<T>
+): WritableComputedRef<T | null> {
+  const args: UseTimedStorageOptions<T> = Object.assign(
+    // Set up object to populate
+    {},
+    // Add in the key-name if it's the only arg.
+    //  We /must/ have keyName, so provide unused default for typing.
+    { keyName: typeof arg1 === 'string' ? arg1 : '' },
+    // Apply the rest of the args, if passed.
+    typeof arg1 === 'object' ? arg1 : {}
+  );
+
+  const {
+    keyName,
+    initialValue = null,
+    liveTime = 5 * 60 * 1000,
+    storage = sessionStorage,
+    storageOptions = {},
+  } = args;
+
   const initialObj: TimedStorageVal<T> | null =
     initialValue === null
       ? null

--- a/ui/src/lib/useTimedStorage.ts
+++ b/ui/src/lib/useTimedStorage.ts
@@ -1,0 +1,64 @@
+import { UseStorageOptions, useSessionStorage } from '@vueuse/core';
+import { differenceInMilliseconds, parseISO } from 'date-fns';
+import { WritableComputedRef, computed } from 'vue';
+
+export interface UseTimedStorageOptions<T> {
+  /** The value to use as the storage key. Always prefixed with `[nh]` */
+  keyName: string;
+  /** The optional value to use as the initial value. @default null */
+  initialValue?: T | null;
+  /** The time this storage value is allowed to be accessed. @default '5m' */
+  liveTime?: number;
+  /** The optional extension value to configure the useStorage native behavior. */
+  storageOptions?: UseStorageOptions<T>;
+}
+
+interface TimedStorageVal<T> {
+  storedAt: Date | string;
+  value: T;
+}
+
+export function useTimedStorage<T>({
+  keyName,
+  initialValue = null,
+  liveTime = 5 * 60 * 1000,
+  storageOptions = {},
+}: UseTimedStorageOptions<T>): WritableComputedRef<T | null> {
+  const initialObj: TimedStorageVal<T> | null =
+    initialValue === null
+      ? null
+      : {
+          storedAt: new Date(),
+          value: initialValue,
+        };
+
+  const storedVal = useSessionStorage<TimedStorageVal<T> | null>('[nh]' + keyName, initialObj, {
+    ...storageOptions.serializer,
+    serializer: storageOptions.serializer ?? {
+      read: JSON.parse,
+      write: JSON.stringify,
+    },
+  });
+
+  return computed<T | null>({
+    get: () => {
+      if (!storedVal.value) {
+        return null;
+      }
+
+      const storedDate =
+        typeof storedVal.value.storedAt === 'string'
+          ? parseISO(storedVal.value.storedAt)
+          : storedVal.value.storedAt;
+      const msSinceStore = differenceInMilliseconds(new Date(), storedDate);
+      console.log('MsStored:', msSinceStore, liveTime, msSinceStore > liveTime);
+
+      if (Math.abs(msSinceStore) > liveTime) {
+        storedVal.value = null;
+      }
+
+      return storedVal.value?.value ?? null;
+    },
+    set: (nv) => (storedVal.value = nv === null ? null : { storedAt: new Date(), value: nv }),
+  });
+}

--- a/ui/src/lib/useTimedStorage/index.ts
+++ b/ui/src/lib/useTimedStorage/index.ts
@@ -1,24 +1,8 @@
-import { StorageLike, StorageSerializers, UseStorageOptions, useStorage } from '@vueuse/core';
+import { StorageSerializers, useStorage } from '@vueuse/core';
 import { differenceInMilliseconds, parseISO } from 'date-fns';
 import { WritableComputedRef, computed } from 'vue';
-
-export interface UseTimedStorageOptions<T> {
-  /** The value to use as the storage key. Always prefixed with `[nh]` */
-  keyName: string;
-  /** The optional value to use as the initial value. @default null */
-  initialValue?: T | null;
-  /** The time this storage value is allowed to be accessed. @default '5m' */
-  liveTime?: number;
-  /** The base storage interface to use for this hook. @default SessionStorage */
-  storage?: StorageLike;
-  /** The optional extension value to configure the useStorage native behavior. */
-  storageOptions?: UseStorageOptions<T>;
-}
-
-interface TimedStorageVal<T> {
-  storedAt: Date | string;
-  value: T;
-}
+import type { TimedStorageVal } from './timedStorageVal';
+import type { UseTimedStorageOptions } from './useTimedStorageOptions';
 
 export function useTimedStorage<T>(keyName: string): WritableComputedRef<T | null>;
 export function useTimedStorage<T>(
@@ -78,3 +62,6 @@ export function useTimedStorage<T>(
     set: (nv) => (storedVal.value = nv === null ? null : { storedAt: new Date(), value: nv }),
   });
 }
+
+export type { TimedStorageVal } from './timedStorageVal';
+export type { UseTimedStorageOptions } from './useTimedStorageOptions';

--- a/ui/src/lib/useTimedStorage/timedStorageVal.ts
+++ b/ui/src/lib/useTimedStorage/timedStorageVal.ts
@@ -1,22 +1,3 @@
-import { StorageLike, UseStorageOptions } from '@vueuse/core';
-
-/**
- * The options to pass to the UseTimedStorage function.
- *  Expand the native version with timed interface.
- */
-export interface UseTimedStorageOptions<T> {
-  /** The value to use as the storage key. Always prefixed with `[nh]` */
-  keyName: string;
-  /** The optional value to use as the initial value. @default null */
-  initialValue?: T | null;
-  /** The time this storage value is allowed to be accessed. @default '5m' */
-  liveTime?: number;
-  /** The base storage interface to use for this hook. @default SessionStorage */
-  storage?: StorageLike;
-  /** The optional extension value to configure the useStorage native behavior. */
-  storageOptions?: UseStorageOptions<T>;
-}
-
 /**
  * The shape of the data to be stored for a Timed Storage value.
  *  This is used to ensure non-stale data is being referenced.

--- a/ui/src/lib/useTimedStorage/timedStorageVal.ts
+++ b/ui/src/lib/useTimedStorage/timedStorageVal.ts
@@ -1,0 +1,27 @@
+import { StorageLike, UseStorageOptions } from '@vueuse/core';
+
+/**
+ * The options to pass to the UseTimedStorage function.
+ *  Expand the native version with timed interface.
+ */
+export interface UseTimedStorageOptions<T> {
+  /** The value to use as the storage key. Always prefixed with `[nh]` */
+  keyName: string;
+  /** The optional value to use as the initial value. @default null */
+  initialValue?: T | null;
+  /** The time this storage value is allowed to be accessed. @default '5m' */
+  liveTime?: number;
+  /** The base storage interface to use for this hook. @default SessionStorage */
+  storage?: StorageLike;
+  /** The optional extension value to configure the useStorage native behavior. */
+  storageOptions?: UseStorageOptions<T>;
+}
+
+/**
+ * The shape of the data to be stored for a Timed Storage value.
+ *  This is used to ensure non-stale data is being referenced.
+ */
+export interface TimedStorageVal<T> {
+  storedAt: Date | string;
+  value: T;
+}

--- a/ui/src/lib/useTimedStorage/useTimedStorageOptions.ts
+++ b/ui/src/lib/useTimedStorage/useTimedStorageOptions.ts
@@ -1,0 +1,18 @@
+import { StorageLike, UseStorageOptions } from '@vueuse/core';
+
+/**
+ * The options to pass to the UseTimedStorage function.
+ *  Expand the native version with timed interface.
+ */
+export interface UseTimedStorageOptions<T> {
+  /** The value to use as the storage key. Always prefixed with `[nh]` */
+  keyName: string;
+  /** The optional value to use as the initial value. @default null */
+  initialValue?: T | null;
+  /** The time this storage value is allowed to be accessed. @default '5m' */
+  liveTime?: number;
+  /** The base storage interface to use for this hook. @default SessionStorage */
+  storage?: StorageLike;
+  /** The optional extension value to configure the useStorage native behavior. */
+  storageOptions?: UseStorageOptions<T>;
+}

--- a/ui/src/repos/user-settings/repository.ts
+++ b/ui/src/repos/user-settings/repository.ts
@@ -52,6 +52,10 @@ export const userSettingsRepository = defineStore('user-settings-repo', () => {
     }
   }
 
+  function clearSettingsCache() {
+    myUserSettings.value = null;
+  }
+
   return {
     // Refs
     myUserSettings,
@@ -63,6 +67,7 @@ export const userSettingsRepository = defineStore('user-settings-repo', () => {
     GET_fetch,
 
     // Functions
+    clearSettingsCache,
     getUserSettings,
   };
 });

--- a/ui/src/repos/user-settings/repository.ts
+++ b/ui/src/repos/user-settings/repository.ts
@@ -1,6 +1,7 @@
 import { useNativeAuth } from '@/auth/useNativeAuth';
+import { useTimedStorage } from '@/lib/useTimedStorage';
 import { type IUserSettings } from '@db/models/UserSettings.d';
-import { useFetch, useSessionStorage } from '@vueuse/core';
+import { useFetch } from '@vueuse/core';
 import { defineStore, storeToRefs } from 'pinia';
 import { computed } from 'vue';
 import { getFetchHeaders } from '../helpers';
@@ -8,9 +9,7 @@ import { getFetchHeaders } from '../helpers';
 export const userSettingsRepository = defineStore('user-settings-repo', () => {
   // Set up the local ref for the settings
   //  Persist to session storage for performance on repeat page-loads.
-  const myUserSettings = useSessionStorage<IUserSettings | null>('user-settings-temp', null, {
-    serializer: { read: JSON.parse, write: JSON.stringify },
-  });
+  const myUserSettings = useTimedStorage<IUserSettings>('user-settings');
 
   // Computed values for the state.
   const myFullName = computed(() =>
@@ -43,7 +42,9 @@ export const userSettingsRepository = defineStore('user-settings-repo', () => {
     // Execute the fetch, update our local ref settings, return the found value.
     try {
       await GET_fetch.execute();
-      myUserSettings.value = GET_fetch.response.value?.ok ? GET_fetch.data.value?.value?.[0] : null;
+      myUserSettings.value = GET_fetch.response.value?.ok
+        ? GET_fetch.data.value?.value?.[0] ?? null
+        : null;
       return myUserSettings.value;
     } catch (err) {
       console.error('Failed to get user settings:', err);

--- a/ui/src/repos/user-settings/repository.ts
+++ b/ui/src/repos/user-settings/repository.ts
@@ -21,7 +21,7 @@ export const userSettingsRepository = defineStore('user-settings-repo', () => {
   const { userId } = storeToRefs(useNativeAuth());
   type GET_Resp = { value: IUserSettings[] };
   const GET_fetch = useFetch<GET_Resp>(
-    `/data-api/direct/user-settings/id/${userId.value ?? ''}`,
+    () => `/data-api/direct/user-settings/id/${userId.value ?? ''}`,
     {
       headers: getFetchHeaders('authenticated'),
       method: 'GET',


### PR DESCRIPTION
# Checks
![Azure Static Web Apps CI/CD](https://github.com/bparker-github/noodles-house/actions/workflows/azure-static-web-apps-thankful-pebble-0fd322f0f.yml)

# Changes
- Add `useTimedStorage` utility to "useStorage" with an expiration time.
  - **Note**, this is not secure - this is just to help cleanup stale data behind the scenes.
- UserSettings storage update for above.
- User Settings clearing out on logout now.
- Fetch user settings once on `App` load
  - Non-blocking startup request - we don't _need_ these, but we want them populated soon
  - These settings can show a user's name and profile pic and other UI settings
  - This should respect local storage of the same data - non-duplicate fetching.
